### PR TITLE
upd ADR template and guide

### DIFF
--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -2,108 +2,369 @@
 
 ## Introduction
 
-This guide covers the process for creating, reviewing, implementing, and maintaining Architectural Decision Records (ADRs) within the QF project. ADRs document significant architectural decisions, their context, alternatives considered, and implementation plans.
+This guide describes the process for creating, reviewing, implementing, and maintaining Architectural Decision Records (ADRs) within the QF project.
 
 ## What is an ADR?
 
-An Architectural Decision Record is a document that captures an important architectural decision made along with its context and consequences. It answers three main questions:
-1. What was decided?
-2. Why was it decided?
-3. How will it be implemented?
+An ADR captures important architectural decisions, answering:
 
-## ADR Lifecycle
+- What was decided?
+- Why was it decided?
+- How will it be implemented?
+
+ADRs are short documents (target length: ~2 pages of text) that follow the **Reader-focused design principle** - structured for those who will read them in the future rather than optimized for the writer. They support the entire decision process from problem identification through knowledge-sharing and implementation.
+**Immutability reminder** - Once an ADR reaches **Accepted**, its Decision, Context, Options, Consequences and Advice are *frozen*. If the decision changes later, create a **new ADR that Supersedes the old one**; never rewrite history.
+
+## ADR Lifecycle Overview
 
 ### 1. Ideation & Creation
-
-ADRs can originate from multiple sources:
-
-- **Team Brainstorming Sessions**: Any developer can propose an ADR during brainstorming or ideation sessions
-- **Architecture Reviews**: Formal review processes identifying needed architectural decisions
-- **Problem Resolution**: When addressing significant technical challenges
-- **Innovation Proposals**: When exploring new technologies or approaches
-
-**Creation Process:**
-1. Use the [ADR template](adr-template.md)
-2. Assign a unique ADR number (sequential)
-3. Set status to "Proposed"
-4. Complete all required sections
-5. Submit as a pull request to the ADR folder in spec repository
+ADRs originate from team brainstorming, architecture reviews, problem resolution needs, or innovation proposals.
 
 ### 2. Review & Decision
+Advice gathering from consulted experts and informed stakeholders, with iterative refinement based on feedback.
 
-Once proposed, ADRs undergo review:
+### 3. Implementation
+Moving from accepted decision through planning, development, and verification phases.
 
-1. **Initial Review**: Team members and relevant stakeholders review for completeness and clarity
-2. **Discussion Period**: Team members provide feedback, ask questions, and suggest alternatives
-3. **Revision**: ADR author updates the document based on feedback
-4. **Decision Meeting**: Key stakeholders meet to make a final decision
-5. **Status Update**: ADR status changed to "Accepted" or "Rejected"
+### 4. Maintenance
+Ongoing management including status updates, superseding when needed, and maintaining decision history.
 
-### 3. Acknowledgment Process
+*Detailed working methods for each phase are provided in the next section.*
 
-For accepted ADRs, team members should formally acknowledge they've read and understood the decision:
+## Working Methods with ADR Template
 
-1. **Initial inclusion**: Key stakeholders are listed in the "Informed" section during ADR creation
-2. **Acknowledgment options**:
-   - During review: Reviewers can check their names as part of the review process for the initial ADR PR
-   - After acceptance: Team members can submit a separate PR to check their name after the ADR is merged
+### Template Section - Completion Sequence
 
-### 4. Implementation
+The template sections can be completed out of order.
+**Recommended sequence:**
+1. **Date** → Set creation and status update dates
+2. **Status** → Set to "Proposed" initially
+3. **People** → Identify Author, Consulted experts, Informed stakeholders
+4. **Context** → Understand the problem space first
+5. **Consequences** → Explore options with benefits/drawbacks/risks
+6. **Options** → Extract clean numbered list from Consequences analysis
+7. **Decision** → Write final decision after advice incorporation
 
-Accepted ADRs move to implementation:
+*This sequence reflects methodology of using ADRs as decision-support tools rather than just documentation.*
 
-1. **Planning**: Determine implementation approach, assign resources, establish timeline
-2. **Development**: Implementation of the architectural decision
-3. **Status Updates**: Regularly update implementation status
-4. **Documentation**: Update external documentation to reflect the decision
+### Method 1: Sequential Writing Process
 
-**Implementation Statuses:**
-- **Planned**: Implementation scheduled but not started
-- **In Development**: Actively being implemented
-- **Implemented**: Implementation complete but not verified
-- **Verified**: Fully tested and confirmed in production
+#### Step 1: Create ADR and Announce Decision Process
+1. **Create new ADR** from template
+2. **Assign unique ADR_id**
+3. **Set descriptive title** reflecting the decision question
+4. **Set status** to "Proposed"
+5. **Add dates** - creation date and last status update
+6. **Identify Author/Decision Owner** - single point of accountability
+7. **Set implementation status** to "Planned" if applicable
+8. **CREATE PR IMMEDIATELY** - Submit PR to the ADR folder in spec repository as soon as ADR is created to announce the start of the decision process and ensure visibility
 
-### 5. Maintenance
+*Key principle: Create PR as early as possible so everyone knows decision work has started, even if sections are incomplete*
 
-Implemented ADRs require ongoing maintenance:
+*Example:*
+```
+ADR_003: (DRAFTING) What if the Leader fails to produce blocks?
 
-1. **Regular Review**: Periodically review all ADRs for relevance
-2. **Status Updates**: Update status if circumstances change
-3. **Deprecation/Superseding**: Mark as deprecated or superseded when necessary
-4. **Linking**: Ensure proper links between related or superseding ADRs
+Status:
+
+- [x] Proposed
+
+Author/Decision Owner: John Smith
+```
+
+#### Step 2: Identify People and Stakeholders
+1. **Author/Decision Owner** - Single point of accountability (you or your team)
+2. **Consulted** - Subject matter experts who will provide advice
+3. **Informed** - People/teams affected by this decision
+
+*Key principle: Identify both those affected by the decision and those with relevant expertise*
+
+#### Step 3: Write the Context Section
+1. **Brain dump** everything relevant to the decision
+2. **Focus on forces and constraints** that led to needing this decision
+3. **Answer "What is the problem?" not "What's the solution?"**
+4. **Include:**
+   - Technical, business, and organizational context
+   - Applicable requirements (functional and cross-functional)
+   - Current state and why change is needed
+   - Key stakeholders and their concerns
+5. **Add Decision Criteria** if explicit evaluation criteria exist
+6. **Add diagrams** if they help explain current state
+7. **Self-check** for adviser audience - do they have enough info?
+
+#### Step 4: Work in Consequences Section First
+1. **Start in Consequences section** - skip Options initially
+2. **Capture all options** you can think of, including:
+   - Options you already have in mind
+   - "Do nothing" option
+   - "Not yet" option
+   - Creative alternatives
+3. **For each option, systematically analyze:**
+   - Brief description
+   - Benefits (what makes this attractive)
+   - Drawbacks (what are the concerns)
+   - Risks and mitigations
+   - **Failure recovery approach**
+4. **Use research and sources** - link to documentation, similar decisions
+5. **Aim for 3-5 options** (avoid analysis paralysis with 10+)
+
+*Key principle: Embrace creative freedom but stay focused on your Context*
+
+#### Step 5: Extract Options List
+Once Consequences section stabilizes:
+1. **Create clean numbered list** in Options section
+2. **Use descriptive names** for each option
+3. **Include brief description** - detailed analysis stays in Consequences
+4. **Always include "do nothing/status quo"** option
+
+#### Step 6: Gather Advice
+1. **Share ADR** in current state to set up focused conversations
+   - Use ADR to prime discussions
+   - Show your thinking and where you need input
+   - Make clear what stage you're at in the process
+
+2. **Conduct advice sessions** with Consulted and Informed people:
+   - Use ADR sections to focus discussion
+   - Take notes during sessions (offer to be note-taker)
+   - Listen actively and ask clarifying questions
+   - Capture advice in raw, unfiltered form
+
+3. **Format advice** in Advice section as:
+   ```
+   [Advice content] ([Name, Role], YYYY-MM-DD)
+   ```
+
+4. **Validate advice** with givers using negative assurance:
+   - Share updated ADR with advice captured
+   - "If you see nothing wrong with the notes, no action needed"
+   - Allow corrections before decision is taken
+
+#### Step 7: Update ADR Based on Advice
+1. **Update ADR sections** based on advice:
+   - **Enhance** Context/Options/Consequences with new insights
+   - **Clarify** any misinterpretations from advice sessions
+   - **Acknowledge** advice not incorporated (show transparency)
+
+#### Step 8: Take Decision and Complete ADR
+1. **Select final option** using structured Consequences format:
+   - **Selected option:**
+     - "Selected because..." for benefits that led to choice
+     - "Selected despite..." for drawbacks you're accepting
+   - **Rejected options:**
+     - "Rejected because..." for critical drawbacks
+     - "Rejected despite..." for benefits you're giving up
+
+2. **Complete remaining sections:**
+   - **Decision section:** Short "We will..." summary for implementers
+   - **Update title:** Reflect actual decision taken
+   - **Implementation Notes:** Specific guidance for implementation
+   - **ADR Relationships:** Link to related/superseded ADRs
+
+3. **Final validation:**
+   - Review if you're confident in this decision
+   - Ensure failure recovery is addressed
+   - Check that implementation approach is actionable
+
+4. **Change status** to "Accepted" and update date
+
+#### Step 9: Share Decision and Begin Implementation
+1. **Notify all stakeholders** of accepted decision
+2. **Update implementation status** as work progresses
+3. **Informed parties acknowledge** by checking their names via PR
+
+### Method 2: Collaborative Development Process
+
+For team decisions or complex contexts:
+
+#### Phase 1: Context Development
+1. **Collaborative brain dump** in team session
+2. **Identify all stakeholders** for People sections
+3. **Create PR immediately** for visibility
+4. **Seek early advice** on problem definition if helpful
+5. **Iterate context** based on initial feedback
+
+#### Phase 2: Options Generation Workshop
+1. **Creative brainstorming** - avoid early convergence on solutions
+2. **Research similar decisions** in organization or industry
+3. **Consider failure modes** and recovery for each option
+4. **Map options to context forces** and constraints
+
+#### Phase 3: Consequences Analysis
+1. **Systematic evaluation** using consistent criteria
+2. **Risk assessment** and mitigation strategies
+3. **Cost-benefit analysis** where applicable
+4. **Impact assessment** on identified stakeholders
+
+#### Phase 4: Decision Taking
+1. **Gather advice** from all identified stakeholders
+2. **Update ADR** based on advice received
+3. **Take decision** using structured selection criteria
+4. **Complete and share** final ADR
 
 ## Roles and Responsibilities
 
-TBD
+### Author/Decision Owner (Single Point of Accountability)
+- **Primary responsibility** for driving the decision process
+- **Single contact point** for questions about the ADR
+- **Accountable** for the decision outcome
+- Usually architect, team lead, or designated decision owner
+- Can be a team if decision is collective, but accountability must be clear
+
+### Consulted (Subject Matter Experts)
+- People with relevant technical or domain expertise
+- Provide advice on options, risks, and implementation approaches
+- Cross-functional representatives (InfoSec, UX, Performance, etc.)
+- Previous decision makers on related topics
+
+### Informed (Affected Parties)
+- Teams that will implement the decision
+- Teams that integrate with or depend on this decision
+- Stakeholders who need awareness but aren't directly consulted
+- End users or customer representatives if applicable
 
 ## ADR Status Tracking
 
-### Primary Status
-- **Proposed**: Initial status for newly created ADRs under consideration
-- **Accepted**: The decision has been approved but implementation may not have started
-- **Rejected**: The decision was considered but not approved
-- **Deprecated**: The decision was previously accepted but is no longer valid
-- **Superseded**: The decision has been replaced by a newer ADR (should reference the new ADR number)
+### Status
+- **Proposed** - ADR created, advice gathering in progress
+- **Accepted** - Decision taken and ready for implementation
+- **Deprecated** - Decision no longer applicable but not directly replaced
+- **Superseded** - Decision replaced by another ADR
+
+*Note: We do not use these statuses:* 
+- "Rejected": Rejected decisions are actually decisions to "do nothing" and should be documented as Accepted ADRs with that option selected.
+- "Draft": Any ADR inside a **Draft PR** is implicitly Draft.
 
 ### Implementation Status
-For accepted ADRs:
+*Implementation tracking extends beyond core ADR methodology to support delivery management.*
+
 - **Planned**: Implementation is scheduled but has not started
 - **In Development**: Implementation is actively in progress
-- **Implemented**: The decision has been fully implemented in the codebase
-- **Verified**: The implementation has been tested and verified in production
-- **Discontinued**: Implementation was started but stopped due to the ADR being superseded or rejected
+- **Implemented** - Decision fully implemented in the system
+- **Verified** - Implementation tested and verified working
+- **Discontinued** - Implementation stopped, rolled back, or abandoned
 
-When an ADR is superseded or rejected after development has begun:
-1. Update the primary status to "Superseded" or "Rejected"
-2. Update the implementation status to "Discontinued"
-3. Add a note in the Decision section explaining why the approach was abandoned
-4. If superseded, include a reference to the new ADR that replaces this one
+### Status Update Protocol
+- Update ADR document when status changes
+- Update last status update date
+- Notify affected teams for major status changes
+- **Ready‑for‑Review note** – Switch the PR from *Draft* to *Ready for review* only when:
 
-### Status Updates
-1. The person changing the status should:
-   - Update the status in the ADR document
-   - Update any status tracking table
-   - Add a comment to the relevant GitHub issue
-   - Update the "Last Updated" date
+  1. Preferred option is marked and Decision section drafted.
+  2. Advice section is complete or a one‑line note states that external advice is unnecessary.
+  3. All mandatory sections are filled enough for final sign‑off.
+- Maintain decision immutability - no changes to decision content after acceptance
 
-2. For major status changes, notify the team through appropriate channels
+### Acknowledgment Process
+
+People listed in "Informed" section should:
+- Submit PR to check their name after reading the ADR
+- Can be done during initial review process or after ADR acceptance
+- Ensures affected parties are aware of decisions
+
+### Maintenance and Superseding
+
+**Ongoing ADR Management:**
+- **Regular reviews** of implemented decisions
+- **Status updates** as circumstances change
+- **Superseding process** when new decisions override old ones:
+  - Create new ADR for the replacement decision
+  - Link new ADR in "Supersedes" section
+  - Update old ADR status to "Superseded"
+  - **Never modify** the original decision content (immutability principle)
+
+## Quality Guidelines
+
+### Essential Template Sections (Always Required)
+1. **Date & Status** - When and what state
+2. **People** - Who's accountable, consulted, informed
+3. **Context** - Why is this decision needed?
+4. **Options** - What alternatives were considered?
+5. **Consequences** - Why was this option selected over others?
+6. **Decision** - What will be implemented?
+
+### Optional But Valuable Sections
+- **Decision Criteria** - Explicit evaluation criteria
+- **Problem** - Clear problem statement
+- **Decision in Details** - Technical implementation details
+- **Advice** - Raw stakeholder input (transparency and learning)
+- **Implementation Notes** - Specific implementation guidance
+- **ADR Relationships** - Links to related decisions
+
+### Core Principles
+
+**Reader-Focused Design**
+- Optimize template structure for future readers
+- Decision section accessible for implementers
+- Context and reasoning available for those who need deeper understanding
+- Clear section hierarchy and logical flow
+
+**Lightweight Approach**
+- Target ~2 pages of content
+- Focus on architecturally significant decisions
+- Avoid unnecessary bureaucracy
+- Use diagrams when they clarify, not decorate
+
+**Immutable Once Accepted**
+- Never update decision content after acceptance
+- Create new superseding ADR for changes
+- Maintain historical decision record
+- Link related ADRs for navigation
+
+**Transparent Process**
+- Document both selected and rejected options
+- Show reasoning for all choices
+- Capture raw advice for learning
+- Make decision process visible to organization
+
+**Clear Accountability**
+- Single point of responsibility for each decision
+- Clear contact for questions and follow-up
+- Defined roles for advisers and stakeholders
+- Explicit implementation ownership
+
+### Common Quality Issues to Avoid
+
+**Process Anti-Patterns:**
+- Single option analysis (always consider alternatives)
+- Post-hoc documentation (ADR written after implementation)
+- Vague problem definition (unclear why decision needed)
+- Missing stakeholder identification (advice from wrong people)
+- Late PR creation (decision work hidden from organization)
+
+**Content Anti-Patterns:**
+- Vague titles that don't convey the decision
+- Missing context about forces and constraints
+- Advice not captured in raw form
+- Benefits without acknowledging trade-offs
+- No consideration of failure scenarios
+
+**Management Anti-Patterns:**
+- Updating accepted ADRs instead of superseding
+- Decisions scattered across multiple tools
+- No linking between related decisions
+- Inconsistent status tracking
+
+## Pre-Decision Quality Checklist
+
+Before finalizing any ADR, verify:
+
+**Content Completeness:**
+- [ ] Context captures forces requiring this decision
+- [ ] 3-5 options considered (including "do nothing")
+- [ ] Decision consequences clearly articulate selection rationale
+- [ ] Failure recovery approach considered for selected option
+- [ ] Implementation approach is actionable
+
+**Stakeholder Engagement:**
+- [ ] All affected parties identified in "Informed" section
+- [ ] Subject matter experts identified in "Consulted" section
+- [ ] Advice gathered from required stakeholders
+- [ ] Advice validated with givers using negative assurance
+
+**Process Integrity:**
+- [ ] Single point of accountability clearly defined
+- [ ] ADR relationships documented (supersedes/related)
+- [ ] Status and dates accurately reflect current state
+- [ ] PR created early for process visibility
+
+This checklist ensures ADR quality while maintaining the lightweight approach essential to the methodology.

--- a/docs/ADR/README.md
+++ b/docs/ADR/README.md
@@ -50,7 +50,7 @@ The template sections can be completed out of order.
 ### Method 1: Sequential Writing Process
 
 #### Step 1: Create ADR and Announce Decision Process
-1. **Create new ADR** from template
+1. **Create new ADR** from [template](./adr-template.md)
 2. **Assign unique ADR_id**
 3. **Set descriptive title** reflecting the decision question
 4. **Set status** to "Proposed"

--- a/docs/ADR/adr-template.md
+++ b/docs/ADR/adr-template.md
@@ -1,19 +1,23 @@
 # ADR Template
 
-## Title: [Descriptive title of the architectural decision]
+## ADR_[ADR_id]: [Descriptive title of the architectural decision]
+
+*Note: This template maintains the Reader-focused design principle. Template sections can be completed out of order. Recommended sequence: Date → Status → People → Context → Consequences → Options → Decision. See ADR Guide for detailed working methods.*
 
 ## Date
-YYYY-MM-DD
+
+Decision date: YYYY-MM-DD
 Last status update: YYYY-MM-DD
 
 ## Status
+
 - [ ] Proposed
 - [ ] Accepted
-- [ ] Rejected
 - [ ] Deprecated
-- [ ] Superseded by ADR #X
+- [ ] Superseded
 
 ### Implementation Status
+
 - [ ] Planned
 - [ ] In Development
 - [ ] Implemented
@@ -21,77 +25,157 @@ Last status update: YYYY-MM-DD
 - [ ] Discontinued
 
 ## People
-- **Decision-makers**: [List of people who made the decision]
-- **Consulted**: [List of subject matter experts consulted]
-- **Informed**: 
-  - [ ] [Person 1] 
+
+### Author/Decision Owner (Single Point of Accountability)
+[Name of person or team accountable for this decision and point of contact for questions]
+  - [Person 1]
+  - [Person 2]
+  - [Person 3]
+
+### Consulted (Subject Matter Experts)
+[List of people with relevant expertise who provided advice]
+
+  - [Person 1]
+  - [Person 2]
+  - [Person 3]
+
+### Informed (Affected Parties)
+[People/teams affected by this decision who should be aware]
+
+  - [ ] [Person 1]
   - [ ] [Person 2]
   - [ ] [Person 3]
-  
+
 *Note: People listed in "Informed" should submit a PR to check their name after reading this ADR. This can be done during the initial review process of the ADR upload/commit PR (when the file is first uploaded to GitHub and the author requests reviews), or in a separate PR after the ADR is merged.*
 
+## Decision
+
+[Briefly describe the decision made in "We will..." format. This section should be concise - it's a declaration of intent for implementers. Detailed reasoning belongs in other sections.]
+
 ## Context
-[Describe the situation that calls for a decision. Include technological, business, and project context that helps explain why this decision is needed.]
+
+[Describe the situation that calls for a decision. Focus on forces, constraints, and circumstances that led to needing this decision. Answer "What is the problem?" not "What's the solution?" Include:
+- Technical, business, and organizational context
+- Applicable requirements (functional and cross-functional)
+- Current state and why change is needed
+- Key stakeholders and their concerns]
+
+### Decision Criteria (Optional)
+
+[Explicit criteria for evaluating options, such as:
+- Performance requirements
+- Cost constraints
+- Security requirements
+- Maintainability needs
+- Time-to-market considerations]
 
 ## Problem (Optional)
+
 [Clearly state the problem being addressed. What issue or opportunity requires this architectural decision?]
 
-## Decision
-[Describe the decision made, including:
+## Decision in Details (Optional)
+
+[Describe in details the decision made, including:
 - Key technical details
 - Implementation approach
 - Timeline considerations
-- Who is responsible]
+- Who is responsible for implementation]
 
 ### Decision Drivers (Optional)
+
 - [Driver 1: Key force or requirement influencing the decision]
 - [Driver 2: Another key consideration]
 - [...]
 
-### Alternatives Considered (Optional)
-[You can use either a simple list format or a detailed analysis with pros and cons:
+## Options
 
-**Simple List Approach**:
-- Alternative 1: [Brief description and reason for rejection]
-- Alternative 2: [Brief description and reason for rejection]
-- etc.
+[Briefly list the considered options. Each option is numbered for easy reference, with the selected option marked clearly as `(SELECTED)`. Aim for 3-5 options minimum. Always include at least "do nothing" option. A detailed description of each option can be written in the Consequences section below.]
 
-**Detailed Analysis Approach**:
-For a more thorough analysis, consider this structure for each alternative:
+1. (SELECTED) [Name of selected option]
+2. [Name of alternative option]
+3. [Name of alternative option]
+4. [Do nothing / Status quo option]
 
-#### Alternative 1: [Name/Title]
-**Description**: [Explanation of the approach]
+## Consequences (Optional)
 
-**Pros**:
-- [Advantage 1]
-- [Advantage 2]
+### Option 1: [Name of option] (SELECTED)
 
-**Cons**:
-- [Disadvantage 1]
-- [Disadvantage 2]
+[Brief description of this option.]
 
-**Why Not Selected**: [Reasons for rejection]
+**Selected because:**
+- [Benefit 1 that led to selection]
+- [Benefit 2 that led to selection]
 
-Repeat for each alternative considered.]
+**Selected despite:**
+- [Drawback 1 that we accept]
+- [Drawback 2 that we accept]
 
-### Consequences (Optional)
-- **Positive**: [List positive impacts of this decision]
-- **Negative**: [List negative impacts or trade-offs]
-- **Risks**: [List any risks associated with this decision and mitigation strategies]
+**Risks and Mitigations:**
+- [Risk 1]
+  - [Mitigation strategy 1]
+- [Risk 2]
+  - [Mitigation strategy 2]
+
+**Failure Recovery:**
+[How will we recover if this option fails?]
+
+### Option 2: [Name of alternative option]
+
+[Brief description of this option.]
+
+**Rejected because:**
+- [Critical drawback 1 - reason for rejection]
+- [Critical drawback 2 - reason for rejection]
+
+**Rejected despite:**
+- [Potential benefit 1 we're giving up]
+- [Potential benefit 2 we're giving up]
+
+*(Repeat for additional options if applicable)*
+
 
 ## Implementation Notes (Optional)
+
 [Any specific guidance for implementing this decision, including:
 - Required dependencies
 - Migration steps
-- Testing considerations]
+- Testing considerations
+- Failure Recovery / Rollback procedures]
 
 ## Confirmation (Optional)
+
 [Describe how the implementation of this decision will be verified. Include:
 - Acceptance criteria
 - Testing approach
-- Any automated verification methods]
+- Automated verification methods]
+
+## Advice (Optional)
+
+[Raw, unfiltered contributions from people who offered advice. his section provides transparency into the decision process and serves as a learning resource.]
+
+- [Advice given] ([Advice-giver's name, role], YYYY-MM-DD)
+- [Advice given] ([Advice-giver's name, role], YYYY-MM-DD)
+
+## Glossary (Optional)
+
+- **[Term]**: [Definition]
 
 ## References
+
 - [Related documents, links, and research materials]
 - [Previous ADRs that influence this decision]
 - [External resources that informed this decision]
+- [Requirements or standards]
+
+## ADR Relationships
+
+[Fill in the section if applicable or leave blank for further filling.]
+
+### Supersedes
+- ADR #[X]: [Brief description of superseded decision]
+
+### Superseded By
+- ADR #[X]: [Brief description of superseding decision]
+
+### Related ADRs
+- ADR #[X]: [Brief description of relationship]


### PR DESCRIPTION
Template changes include removing "Rejected" status in favor of documenting "do nothing" decisions as Accepted ADRs, adding Reader-focused design, structured format of some sections. 
Guide changes clarify immediate PR creation requirement, add comprehensive working methods and quality guidelines with pre-decision checklist. 
Result is methodology transforming ADRs from documentation into active decision-making tools with clear accountability and transparent process.